### PR TITLE
Вызов события CollectionHasBeenClearedEvent при удалении медиа

### DIFF
--- a/src/Fields/MediaLibrary.php
+++ b/src/Fields/MediaLibrary.php
@@ -11,6 +11,7 @@ use MoonShine\Fields\Image;
 use MoonShine\Traits\Fields\FileDeletable;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\MediaCollections\Events\CollectionHasBeenClearedEvent;
 
 class MediaLibrary extends Image
 {
@@ -88,6 +89,8 @@ class MediaLibrary extends Image
                 && !$oldValues->contains('id', $media->getKey())
             ) {
                 $media->delete();
+				unset($item->media);
+                event(new CollectionHasBeenClearedEvent($item, $media->collection_name));
             }
         }
     }


### PR DESCRIPTION
Необходимо было подвязаться на событие удаления медиа. В `Spatie\MediaLibrary` как раз есть подобный эвент `CollectionHasBeenClearedEvent`.

Добавил его на удаление медиа в методе `removeOldMedia`. Историю с unset взял из трейта `Spatie\MediaLibrary\InteractsWithMedia(427)`. Без этого `getMedia` будет возвращать удалённые на данный момент записи.

p.s.
Возможно я делаю реквест не в ту ветку, заранее прошу прощения.