### PR TITLE
fix: sorting and removal

### DIFF
--- a/src/Fields/MediaLibrary.php
+++ b/src/Fields/MediaLibrary.php
@@ -52,6 +52,8 @@ class MediaLibrary extends Image
             fn($model) => Media::make(json_decode($model, true))
         );
 
+        $this->orderMedia($oldValues);
+        
         $requestValue = $this->getRequestValue();
 
         $recentlyCreated = collect();
@@ -68,7 +70,7 @@ class MediaLibrary extends Image
 
         $this->removeOldMedia($data, $recentlyCreated, $oldValues);
 
-        $this->orderMedia($recentlyCreated);
+       $this->getData()->getOriginal()->refresh();
 
         return null;
     }


### PR DESCRIPTION
Починил сортировку перетаскиванием изображений, а также визуальные баги, когда после удаления или пересортировки изображений, при сохранении возвращались старые данные до первого обновления страницы.