### PR TITLE
ref: remove lagacy function

### DIFF
--- a/src/Fields/MediaLibrary.php
+++ b/src/Fields/MediaLibrary.php
@@ -130,23 +130,6 @@ class MediaLibrary extends Image
         $values->diff([$this->getValue()])->each(fn (string $file) => $this->deleteFile($file));
     }
 
-    public function removeExcludedFilesPatched(null|array|string $newValue = null): void
-    {
-        $values = collect(
-            $this->toValue(withDefault: false),
-        );
-
-        $values->diff([$this->getValue()])->each(
-            function (?string $file) use ($newValue): void {
-                $old = array_filter(\is_array($newValue) ? $newValue : [$newValue]);
-
-                if ($file !== null && ! \in_array($file, $old, true)) {
-                    $this->deleteFile($file);
-                }
-            },
-        );
-    }
-
     public function getRequestValue(int|string|null $index = null): mixed
     {
         return $this->prepareRequestValue(


### PR DESCRIPTION
Удалил метод, который не нужен в четвертой версии moonshine.