### PR TITLE
Fix: Исправление двойной загрузки (мусор в корне)

### DIFF
--- a/src/Fields/MediaLibrary.php
+++ b/src/Fields/MediaLibrary.php
@@ -1,67 +1,84 @@
 <?php
 
-namespace VI\MoonShineSpatieMediaLibrary\Fields;
+declare(strict_types=1);
+
+namespace App\MoonShine\Fields;
 
 use Closure;
-use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
-use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Support\DTOs\FileItem;
 use MoonShine\UI\Fields\Image;
-use MoonShine\UI\Traits\Fields\FileDeletable;
 use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class MediaLibrary extends Image
 {
-
+    /**
+     * @param  array      $raw
+     * @param  mixed|null $casted
+     * @return mixed
+     */
     protected function prepareFill(array $raw = [], mixed $casted = null): mixed
     {
-        $value = $casted->getOriginal()->getMedia($this->column);
+        $value = $casted->getOriginal()->getMedia($this->getColumn());
 
-        if (!$this->isMultiple()) {
+        if (! $this->isMultiple()) {
             $value = $value->first();
         }
 
         return $value;
     }
 
+    /**
+     * @return array|null[]|string[]
+     */
     public function getFullPathValues(): array
     {
         $values = $this->value;
 
-        if (!$values) {
+        if (! $values) {
             return [];
         }
 
         return $this->isMultiple()
-            ? $this->value->map(fn($media): string => $media->getFullUrl())->toArray()
+            ? $this->value->map(fn ($media): string => $media->getFullUrl())->toArray()
             : [$this->value?->getFullUrl()];
     }
 
+    /**
+     * @return Closure|null
+     */
     protected function resolveOnApply(): ?Closure
     {
-        return static fn($item) => $item;
+        return static fn ($item) => $item;
     }
 
+    /**
+     * @param mixed $data
+     *
+     * @throws FileDoesNotExist
+     * @throws FileIsTooBig
+     *
+     * @return mixed
+     */
     protected function resolveAfterApply(mixed $data): mixed
     {
         $oldValues = request()->collect($this->getHiddenRemainingValuesKey())->map(
-            fn($model) => Media::make(json_decode($model, true))
+            fn ($model) => Media::make(json_decode($model, true))
         );
 
         $this->orderMedia($oldValues);
-        
+
         $requestValue = $this->getRequestValue();
 
         $recentlyCreated = collect();
         if ($requestValue !== false) {
-            if (!$this->isMultiple()) {
+            if (! $this->isMultiple()) {
                 $requestValue = [$requestValue];
             }
-
 
             foreach ($requestValue as $file) {
                 $recentlyCreated->push($this->addMedia($data, $file));
@@ -70,58 +87,93 @@ class MediaLibrary extends Image
 
         $this->removeOldMedia($data, $recentlyCreated, $oldValues);
 
-       $this->getData()->getOriginal()->refresh();
+        $this->getData()->getOriginal()->refresh();
 
         return null;
     }
 
+    /**
+     * @param  mixed $data
+     * @return mixed
+     */
     protected function resolveAfterDestroy(mixed $data): mixed
     {
         $data
             ->getOriginal()
-            ->getMedia($this->column)
-            ->each(fn(Media $media) => $media->delete());
+            ->getMedia($this->getColumn())
+            ->each(fn (Media $media) => $media->delete());
 
         return $data;
     }
 
+    /**
+     * @param HasMedia   $item
+     * @param Collection $recentlyCreated
+     * @param Collection $oldValues
+     */
     private function removeOldMedia(HasMedia $item, Collection $recentlyCreated, Collection $oldValues): void
     {
-        foreach ($item->getMedia($this->column) as $media) {
+        foreach ($item->getMedia($this->getColumn()) as $media) {
             if (
-                !$recentlyCreated->contains('id', $media->getKey())
-                && !$oldValues->contains('id', $media->getKey())
+                ! $recentlyCreated->contains('id', $media->getKey())
+                && ! $oldValues->contains('id', $media->getKey())
             ) {
                 $media->delete();
             }
         }
     }
 
+    /**
+     * @param HasMedia     $item
+     * @param UploadedFile $file
+     *
+     * @throws FileDoesNotExist
+     * @throws FileIsTooBig
+     *
+     * @return Media
+     */
     private function addMedia(HasMedia $item, UploadedFile $file): Media
     {
         return $item->addMedia($file)
             ->preservingOriginal()
-            ->toMediaCollection($this->column);
+            ->toMediaCollection($this->getColumn());
     }
 
+    /**
+     * @param Collection $recentlyCreated
+     */
     private function orderMedia(Collection $recentlyCreated): void
     {
         Media::setNewOrder($recentlyCreated->pluck('id')->toArray());
     }
 
+    /**
+     * @return Collection
+     */
     protected function getFiles(): Collection
     {
+        $mediaItems = collect($this->toValue());
+
         return collect($this->getFullPathValues())
-            ->mapWithKeys(fn (string $path, int $index): array => [
-                $index => new FileItem(
-                    fullPath: $path,
-                    rawValue: data_get($this->toValue(), $index, $this->toValue()),
-                    name: (string) \call_user_func($this->resolveNames(), $path, $index, $this),
-                    attributes: \call_user_func($this->resolveItemAttributes(), $path, $index, $this),
-                ),
-            ]);
+            ->mapWithKeys(function (string $path, int $index) use ($mediaItems): array {
+                $item = $mediaItems->get($index);
+
+                $rawValue = $item instanceof Media ? $item->file_name : $path;
+
+                return [
+                    $index => new FileItem(
+                        fullPath: $path,
+                        rawValue: (string) $rawValue,
+                        name: (string) \call_user_func($this->resolveNames(), $path, $index, $this),
+                        attributes: \call_user_func($this->resolveItemAttributes(), $path, $index, $this),
+                    ),
+                ];
+            });
     }
 
+    /**
+     * @param array|string|null $newValue
+     */
     public function removeExcludedFiles(null|array|string $newValue = null): void
     {
         $values = collect([
@@ -131,6 +183,10 @@ class MediaLibrary extends Image
         $values->diff([$this->getValue()])->each(fn (string $file) => $this->deleteFile($file));
     }
 
+    /**
+     * @param  int|string|null $index
+     * @return mixed
+     */
     public function getRequestValue(int|string|null $index = null): mixed
     {
         return $this->prepareRequestValue(
@@ -140,11 +196,13 @@ class MediaLibrary extends Image
         );
     }
 
+    /**
+     * @param  Closure $default
+     * @param  mixed   $data
+     * @return mixed
+     */
     public function apply(Closure $default, mixed $data): mixed
     {
-        $item = parent::apply($default, $data);
-        unset($item->{$this->column});
-
-        return $item;
+        return $data;
     }
 }

--- a/src/Fields/MediaLibrary.php
+++ b/src/Fields/MediaLibrary.php
@@ -5,6 +5,7 @@ namespace VI\MoonShineSpatieMediaLibrary\Fields;
 use Closure;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
+use MoonShine\Contracts\UI\ApplyContract;
 use MoonShine\Support\DTOs\FileItem;
 use MoonShine\UI\Fields\Image;
 use Spatie\MediaLibrary\HasMedia;
@@ -14,11 +15,6 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class MediaLibrary extends Image
 {
-    /**
-     * @param  array      $raw
-     * @param  mixed|null $casted
-     * @return mixed
-     */
     protected function prepareFill(array $raw = [], mixed $casted = null): mixed
     {
         $value = $casted->getOriginal()->getMedia($this->getColumn());
@@ -30,9 +26,6 @@ class MediaLibrary extends Image
         return $value;
     }
 
-    /**
-     * @return array|null[]|string[]
-     */
     public function getFullPathValues(): array
     {
         $values = $this->value;
@@ -46,22 +39,16 @@ class MediaLibrary extends Image
             : [$this->value?->getFullUrl()];
     }
 
-    /**
-     * @return Closure|null
-     */
+    public function getApplyClass(string $type = 'fields', ?string $for = null): ?ApplyContract
+    {
+        return null;
+    }
+
     protected function resolveOnApply(): ?Closure
     {
         return static fn ($item) => $item;
     }
 
-    /**
-     * @param mixed $data
-     *
-     * @throws FileDoesNotExist
-     * @throws FileIsTooBig
-     *
-     * @return mixed
-     */
     protected function resolveAfterApply(mixed $data): mixed
     {
         $oldValues = request()->collect($this->getHiddenRemainingValuesKey())->map(
@@ -90,10 +77,6 @@ class MediaLibrary extends Image
         return null;
     }
 
-    /**
-     * @param  mixed $data
-     * @return mixed
-     */
     protected function resolveAfterDestroy(mixed $data): mixed
     {
         $data
@@ -104,11 +87,6 @@ class MediaLibrary extends Image
         return $data;
     }
 
-    /**
-     * @param HasMedia   $item
-     * @param Collection $recentlyCreated
-     * @param Collection $oldValues
-     */
     private function removeOldMedia(HasMedia $item, Collection $recentlyCreated, Collection $oldValues): void
     {
         foreach ($item->getMedia($this->getColumn()) as $media) {
@@ -122,13 +100,8 @@ class MediaLibrary extends Image
     }
 
     /**
-     * @param HasMedia     $item
-     * @param UploadedFile $file
-     *
      * @throws FileDoesNotExist
      * @throws FileIsTooBig
-     *
-     * @return Media
      */
     private function addMedia(HasMedia $item, UploadedFile $file): Media
     {
@@ -137,17 +110,11 @@ class MediaLibrary extends Image
             ->toMediaCollection($this->getColumn());
     }
 
-    /**
-     * @param Collection $recentlyCreated
-     */
     private function orderMedia(Collection $recentlyCreated): void
     {
         Media::setNewOrder($recentlyCreated->pluck('id')->toArray());
     }
 
-    /**
-     * @return Collection
-     */
     protected function getFiles(): Collection
     {
         return collect($this->getFullPathValues())
@@ -161,9 +128,6 @@ class MediaLibrary extends Image
             ]);
     }
 
-    /**
-     * @param array|string|null $newValue
-     */
     public function removeExcludedFiles(null|array|string $newValue = null): void
     {
         $values = collect([
@@ -173,10 +137,6 @@ class MediaLibrary extends Image
         $values->diff([$this->getValue()])->each(fn (string $file) => $this->deleteFile($file));
     }
 
-    /**
-     * @param  int|string|null $index
-     * @return mixed
-     */
     public function getRequestValue(int|string|null $index = null): mixed
     {
         return $this->prepareRequestValue(
@@ -186,13 +146,11 @@ class MediaLibrary extends Image
         );
     }
 
-    /**
-     * @param  Closure $default
-     * @param  mixed   $data
-     * @return mixed
-     */
     public function apply(Closure $default, mixed $data): mixed
     {
-        return $data;
+        $item = parent::apply($default, $data);
+        unset($item->{$this->getColumn()});
+
+        return $item;
     }
 }

--- a/src/Fields/MediaLibrary.php
+++ b/src/Fields/MediaLibrary.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\MoonShine\Fields;
+namespace VI\MoonShineSpatieMediaLibrary\Fields;
 
 use Closure;
 use Illuminate\Http\UploadedFile;

--- a/src/Fields/MediaLibrary.php
+++ b/src/Fields/MediaLibrary.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace VI\MoonShineSpatieMediaLibrary\Fields;
 
 use Closure;
@@ -152,23 +150,15 @@ class MediaLibrary extends Image
      */
     protected function getFiles(): Collection
     {
-        $mediaItems = collect($this->toValue());
-
         return collect($this->getFullPathValues())
-            ->mapWithKeys(function (string $path, int $index) use ($mediaItems): array {
-                $item = $mediaItems->get($index);
-
-                $rawValue = $item instanceof Media ? $item->file_name : $path;
-
-                return [
-                    $index => new FileItem(
-                        fullPath: $path,
-                        rawValue: (string) $rawValue,
-                        name: (string) \call_user_func($this->resolveNames(), $path, $index, $this),
-                        attributes: \call_user_func($this->resolveItemAttributes(), $path, $index, $this),
-                    ),
-                ];
-            });
+            ->mapWithKeys(fn (string $path, int $index): array => [
+                $index => new FileItem(
+                    fullPath: $path,
+                    rawValue: data_get($this->toValue(), $index, $this->toValue()),
+                    name: (string) \call_user_func($this->resolveNames(), $path, $index, $this),
+                    attributes: \call_user_func($this->resolveItemAttributes(), $path, $index, $this),
+                ),
+            ]);
     }
 
     /**


### PR DESCRIPTION
## **🐛 Найденные проблемы**
**В текущей версии компонента обнаружены критические проблемы:**

Мусорные файлы в корне диска (Double Upload): Так как класс наследуется от MoonShine\UI\Fields\Image, метод apply() по умолчанию сохраняет файл. Поскольку в Spatie-полях метод dir() обычно не используется (пути определяет PathGenerator).

## **🛠 Что изменено**
Отключена стандартная логика apply
Переопределен метод apply. Теперь он не вызывает parent::apply, а возвращает данные как есть. Это предотвращает перехват файла MoonShine-ом. Файл остается во временной директории пока Spatie не заберет его в методе resolveAfterApply.

```php
public function apply(Closure $default, mixed $data): mixed
{
    // Отключаем нативную загрузку MoonShine.
    // Загрузка полностью делегируется Spatie.
    return $data;
}
```

Сравнение файловой структуры (Пример S3)
```
s3-bucket/
├── 4f5a2...jpg          <-- МУСОР (создан MoonShine Image::apply)
└── title/             <-- Правильная папка (создана Spatie)
    └── 1/
        └── cover/
            └── 4f5a2...jpg
```

После исправления (New Behavior):
```
s3-bucket/
├── title/
│   └── 1/
│       └── cover/
│           └── 4f5a2...jpg
└── (root is clean)      <-- Корень чист
```